### PR TITLE
Add example Gamify Life chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# gamifylife
+# Gamify Life AI Prototype
+
+This repository demonstrates a small prototype for training and serving a chatbot using the Gamify Life framework. The workflow includes generating vector embeddings from text files that describe concepts such as **DAB**, **GRIPS**, **GLOWS**, **DRIFT**, and **FAITH**. The chatbot runs with FastAPI and retrieves answers using LangChain with ChromaDB and OpenAI.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Generate embeddings from the framework files:
+   ```bash
+   python train_embeddings.py
+   ```
+3. Start the FastAPI server:
+   ```bash
+   uvicorn app:app --reload
+   ```
+4. Send POST requests to `/chat` with JSON:
+   ```json
+   {
+     "user_id": "alice",
+     "message": "How do I avoid DRIFT?"
+   }
+   ```
+
+The response contains the assistant's answer and the user's accumulated XP based on positive or negative sentiment words in the message.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,54 @@
+import os
+import json
+from typing import List
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import Chroma
+from langchain.chat_models import ChatOpenAI
+from langchain.chains import RetrievalQA
+
+app = FastAPI()
+
+class UserMessage(BaseModel):
+    user_id: str
+    message: str
+
+# Load knowledge base
+if os.path.exists('framework_embeddings.json'):
+    with open('framework_embeddings.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    texts = [item['text'] for item in data.values()]
+    metadatas = [{'source': name} for name in data.keys()]
+else:
+    texts = []
+    metadatas = []
+
+# Initialize embeddings and vector store
+embedding_model = OpenAIEmbeddings()
+vectorstore = Chroma.from_texts(texts, embedding_model, metadatas=metadatas, collection_name="framework")
+
+llm = ChatOpenAI(temperature=0)
+qa_chain = RetrievalQA.from_chain_type(llm, retriever=vectorstore.as_retriever())
+
+# Simple in-memory XP store
+user_xp = {}
+
+negative_words = {"guilt", "resentment", "fear", "shame"}
+positive_words = {"love", "gratitude", "trust", "safety"}
+
+@app.post("/chat")
+def chat(msg: UserMessage):
+    response = qa_chain.run(msg.message)
+
+    xp = 0
+    text = msg.message.lower()
+    if any(word in text for word in negative_words):
+        xp -= 1
+    if any(word in text for word in positive_words):
+        xp += 1
+
+    user_xp[msg.user_id] = user_xp.get(msg.user_id, 0) + xp
+
+    return {"response": response, "xp": user_xp[msg.user_id]}

--- a/framework/dab.txt
+++ b/framework/dab.txt
@@ -1,0 +1,1 @@
+DAB stands for Desired Alignment Breathing. It represents intentional action toward your highest alignment.

--- a/framework/drift.txt
+++ b/framework/drift.txt
@@ -1,0 +1,1 @@
+DRIFT describes the tendency to Delay Resolve and Ignore Fears that Trigger us. When we drift we move away from alignment.

--- a/framework/faith.txt
+++ b/framework/faith.txt
@@ -1,0 +1,1 @@
+FAITH is Fully Allowing Inspired Trust to Harmonize. It means releasing control and acting from confidence in your path.

--- a/framework/glows.txt
+++ b/framework/glows.txt
@@ -1,0 +1,1 @@
+GLOWS stands for Gratitude, Love, Openness, Worthiness, and Safety. These emotions reflect alignment with your higher self.

--- a/framework/grips.txt
+++ b/framework/grips.txt
@@ -1,0 +1,1 @@
+GRIPS stands for Guilt, Resentment, Insecurity, Pride, and Shame. These emotions signal misalignment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+langchain
+chromadb
+sentence-transformers
+openai

--- a/train_embeddings.py
+++ b/train_embeddings.py
@@ -1,0 +1,21 @@
+import os
+import json
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer('all-MiniLM-L6-v2')
+knowledge = {}
+
+for filename in os.listdir('framework'):
+    path = os.path.join('framework', filename)
+    with open(path, 'r', encoding='utf-8') as f:
+        text = f.read()
+        embedding = model.encode(text)
+    knowledge[filename] = {
+        'text': text,
+        'embedding': embedding.tolist()
+    }
+
+with open('framework_embeddings.json', 'w', encoding='utf-8') as f:
+    json.dump(knowledge, f, ensure_ascii=False, indent=2)
+
+print('Saved embeddings for', len(knowledge), 'documents.')


### PR DESCRIPTION
## Summary
- demonstrate minimal FastAPI chatbot using the Gamify Life framework
- include example framework text files and script to generate embeddings
- add requirements.txt and instructions in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685089489f10832ab79c3f702b35e773